### PR TITLE
docs(readme): change createAndStart to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The two available experiment types are `singlenode` and `multinode`.
 
 To create and immediately start new experiment use:
 ```
-gradient experiments createAndStart [type] [--options]
+gradient experiments run [type] [--options]
 ```
 
 For a full list of available commands run `paperspace experiments --help`. 


### PR DESCRIPTION
this was the only instance of `createAndRun` that i found in the docs. can this be updated at pypi without doing a new release somehow, since the `run` change has already been released? cc @mkulaczkowski @BartoszCki 