### PR TITLE
Edit deprecated method to reduce perceived severity

### DIFF
--- a/gradient/cli/common.py
+++ b/gradient/cli/common.py
@@ -46,7 +46,7 @@ https://docs.paperspace.com
 If you depend on functionality not listed there, please file an issue."""
 
     def new_invoke(self, ctx):
-        click.echo(click.style(deprecated_invoke_notice, fg='red'), err=True)
+        click.echo(click.style(deprecated_invoke_notice, fg='yellow'), err=False)
         super(type(self), self).invoke(ctx)
 
     def decorator(f):


### PR DESCRIPTION
Hello, I received a message from the `deprecated` decorator in the context below. It's a bit intense to receive a red message in std.err given that I am not even using the options discussed in the message. I thought my job hadn't been created at first sight.

I don't know all the places where the decorator is used, so an alternative option to the one presented in this PR would be to set an extra parameter to the method in situations where showing a red message is too severe for the context, as such:

```
def deprecated(msg, err=True):
    deprecated_invoke_notice = msg + """\nFor more information, please see:
https://docs.paperspace.com
If you depend on functionality not listed there, please file an issue."""

    def new_invoke(self, ctx):
        fg = 'red' if err else 'yellow'
        click.echo(click.style(deprecated_invoke_notice, fg=fg), err=err)
        super(type(self), self).invoke(ctx)

    def decorator(f):
```



![Screen Shot 2019-09-20 at 2 07 45 PM](https://user-images.githubusercontent.com/9539763/65351356-e0e24700-dbb5-11e9-993b-fbbb4f8d896f.png)