### PR TITLE
Behaviour of StopIteration changed in Python 3.7 so I'm switching to …

### DIFF
--- a/gradient/api_sdk/repositories/experiments.py
+++ b/gradient/api_sdk/repositories/experiments.py
@@ -110,7 +110,7 @@ class ListExperimentLogs(ListResources):
             for log in logs:
                 # stop generator - "PSEOF" indicates there are no more logs
                 if log.message == "PSEOF":
-                    raise StopIteration()
+                    return
 
                 last_line_number += 1
                 yield log

--- a/tests/functional/test_experiments.py
+++ b/tests/functional/test_experiments.py
@@ -1122,6 +1122,7 @@ class TestExperimentLogs(object):
                                        params={"line": 20, "limit": 30, "experimentId": "some-id"})
         assert "Downloading https://storage.googleapis.com/cvdf-datasets/mnist/t10k-labels" \
                "-idx1-ubyte.gz to /tmp/tmpbrss4txl.gz" in result.output
+        assert result.exit_code == 0
 
     @mock.patch("gradient.api_sdk.clients.http_client.requests.get")
     def test_should_send_get_request_and_print_all_received_logs_when_logs_command_was_used_with_follow_flag(self, get_patched):


### PR DESCRIPTION
…using 'return' to stop a generator