### PR TITLE
Update model upload CLI command to work with file or directory

### DIFF
--- a/gradient/api_sdk/clients/model_client.py
+++ b/gradient/api_sdk/clients/model_client.py
@@ -25,10 +25,10 @@ class ModelsClient(BaseClient):
         repository = repositories.DeleteModel(api_key=self.api_key, logger=self.logger)
         repository.delete(model_id)
 
-    def upload(self, file_handle, name, model_type, model_summary=None, notes=None):
+    def upload(self, path, name, model_type, model_summary=None, notes=None):
         """Upload model
 
-        :param file file_handle: Model file handle
+        :param file path: path to Model
         :param str name: Model name
         :param str model_type: Model Type
         :param dict|None model_summary: Dictionary describing model parameters like loss, accuracy, etc.
@@ -46,7 +46,7 @@ class ModelsClient(BaseClient):
         )
 
         repository = repositories.UploadModel(api_key=self.api_key, logger=self.logger)
-        model_id = repository.create(model, file_handle=file_handle)
+        model_id = repository.create(model, file_handle=path)
         return model_id
 
     def get(self, model_id):

--- a/gradient/api_sdk/repositories/models.py
+++ b/gradient/api_sdk/repositories/models.py
@@ -92,10 +92,11 @@ class UploadModel(GetBaseModelsApiUrlMixin, CreateResource):
             file_name = os.path.basename(path)
             files.append((file_name, open(path, "rb")))
         elif os.path.isdir(path):
-            files_path = glob.glob(path + "/*", recursive=True)
+            files_path = glob.glob(path + "/**", recursive=True)
             for file_path in files_path:
-                file_name = os.path.relpath(file_path, path)
-                files.append((file_name, open(file_path, "rb")))
+                if os.path.isfile(file_path):
+                    file_name = os.path.relpath(file_path, path)
+                    files.append((file_name, open(file_path, "rb")))
         return files
 
 

--- a/gradient/api_sdk/repositories/models.py
+++ b/gradient/api_sdk/repositories/models.py
@@ -1,3 +1,4 @@
+import glob
 import os
 
 import gradient.api_sdk.config
@@ -77,13 +78,25 @@ class UploadModel(GetBaseModelsApiUrlMixin, CreateResource):
 
     def _get_request_files(self, file_handle):
         """
-        :param file file_handle:
+        :param str file_handle: path to Model that will be uploaded
         """
         if not file_handle:
             return None
 
-        file_name = os.path.basename(file_handle.name)
-        return [(file_name, file_handle)]
+        return self._prepare_files(file_handle)
+
+    @staticmethod
+    def _prepare_files(path):
+        files = list()
+        if os.path.isfile(path):
+            file_name = os.path.basename(path)
+            files.append((file_name, open(path, "rb")))
+        elif os.path.isdir(path):
+            files_path = glob.glob(path + "/*", recursive=True)
+            for file_path in files_path:
+                file_name = os.path.relpath(file_path, path)
+                files.append((file_name, open(file_path, "rb")))
+        return files
 
 
 class GetModel(GetBaseModelsApiUrlMixin, GetResource):

--- a/gradient/cli/models.py
+++ b/gradient/cli/models.py
@@ -46,10 +46,10 @@ def list_models(api_key, model_id, options_file):
     command.execute(model_id=model_id)
 
 
-@models_group.command("upload", help="Upload model")
+@models_group.command("upload", help="Upload a model file or directory")
 @click.argument(
-    "FILE",
-    type=click.File(),
+    "PATH",
+    type=click.Path(exists=True),
     cls=common.GradientArgument,
 )
 @click.option(
@@ -82,9 +82,9 @@ def list_models(api_key, model_id, options_file):
 )
 @common.api_key_option
 @common.options_file
-def upload_model(file, name, model_type, model_summary, notes, api_key, options_file):
+def upload_model(path, name, model_type, model_summary, notes, api_key, options_file):
     command = models_commands.UploadModel(api_key=api_key)
-    command.execute(file, name, model_type, model_summary, notes)
+    command.execute(path, name, model_type, model_summary, notes)
 
 
 @models_group.command("details", help="Model details")

--- a/gradient/commands/models.py
+++ b/gradient/commands/models.py
@@ -46,9 +46,9 @@ class DeleteModelCommand(GetModelsClientMixin, BaseCommand):
 class UploadModel(GetModelsClientMixin, BaseCommand):
     SPINNER_MESSAGE = "Uploading model"
 
-    def execute(self, file_handle, name, model_type, model_summary, notes):
+    def execute(self, path, name, model_type, model_summary, notes):
         with halo.Halo(text=self.SPINNER_MESSAGE, spinner="dots"):
-            model_id = self.client.upload(file_handle, name, model_type, model_summary, notes)
+            model_id = self.client.upload(path, name, model_type, model_summary, notes)
 
         self.logger.log("Model uploaded with ID: {}".format(model_id))
 

--- a/tests/config_files/models_upload.yaml
+++ b/tests/config_files/models_upload.yaml
@@ -1,4 +1,4 @@
-FILE: saved_model.pb
+PATH: saved_model.pb
 apiKey: some_key
 modelSummary:
   key: value


### PR DESCRIPTION
**Ticket:** https://paperspace.atlassian.net/browse/PS-12321
**Description of changes:**
Previously model upload in CLI was working only with file. To change it to work with file or directory argument filter was changes from `click.File()` to `click.Path(exist=True)` so now we do not open file on command start but pass string with provided path.
The issue to solve in further stage of changes be sure that relative directory structure is correct and probably try to use streaming with upload (in case if there would be one file much bigger)