### PR TITLE
Change option `--id` to required for notebook show

### DIFF
--- a/gradient/cli/notebooks.py
+++ b/gradient/cli/notebooks.py
@@ -121,6 +121,7 @@ def list_notebooks(api_key, options_file):
     "id",
     help="Notebook ID",
     cls=common.GradientOption,
+    required=True,
 )
 @common.api_key_option
 @common.options_file


### PR DESCRIPTION
**Ticket:** https://paperspace.atlassian.net/browse/PS-12550
**Description:** Change `--id` parameter to required. That cause that if not passed then error message looks like this `Error: Missing option "--id".`