### PR TITLE
Revert "Pass clusterhandle to experiments workspace"

### DIFF
--- a/gradient/workspace.py
+++ b/gradient/workspace.py
@@ -128,13 +128,12 @@ class S3WorkspaceHandler(WorkspaceHandler):
 
         archive_path = workspace
         project_handle = input_data.get('projectHandle') or input_data["project_id"]
-        cluster_id = input_data.get('clusterId') or input_data.get("cluster_id")
-        workspace = self._upload(archive_path, project_handle, cluster_id=cluster_id)
+        workspace = self._upload(archive_path, project_handle)
         return workspace
 
-    def _upload(self, archive_path, project_id, cluster_id=None):
+    def _upload(self, archive_path, project_id):
         uploader = self._get_workspace_uploader(self.api_key)
-        workspace = uploader.upload(archive_path, project_id, cluster_id=cluster_id)
+        workspace = uploader.upload(archive_path, project_id)
         return workspace
 
     def _get_workspace_uploader(self, api_key):

--- a/tests/functional/test_experiments.py
+++ b/tests/functional/test_experiments.py
@@ -337,7 +337,7 @@ class TestExperimentsCreateSingleNode(object):
             "https://services.paperspace.io/experiments/v1/workspace/get_presigned_url",
             headers=self.EXPECTED_HEADERS,
             json=None,
-            params={"projectHandle": "testHandle", "workspaceName": zip_file_name, "clusterHandle": 'cluster'},
+            params={"projectHandle": "testHandle", "workspaceName": zip_file_name},
         )
 
         post_patched.assert_has_calls(

--- a/tests/unit/test_workspace.py
+++ b/tests/unit/test_workspace.py
@@ -60,7 +60,7 @@ class TestWorkspace(object):
 
         workspace_handler._zip_workspace.assert_called_once()
         workspace_handler._upload.assert_called_once()
-        workspace_handler._upload.assert_called_with(archive_name, "some_project_id", cluster_id=None)
+        workspace_handler._upload.assert_called_with(archive_name, "some_project_id")
         assert response_url == 's3://{}/{}'.format(MOCK_BUCKET_NAME, MOCK_OBJECT_KEY)
 
     @mock.patch("gradient.utils.PathParser.parse_path",
@@ -75,7 +75,7 @@ class TestWorkspace(object):
 
         workspace_handler._zip_workspace.assert_called_once()
         workspace_handler._upload.assert_called_once()
-        workspace_handler._upload.assert_called_with(archive_name, "some_project_id", cluster_id=None)
+        workspace_handler._upload.assert_called_with(archive_name, "some_project_id")
         assert response_url == 's3://{}/{}'.format(MOCK_BUCKET_NAME, MOCK_OBJECT_KEY)
 
     @mock.patch("gradient.utils.PathParser.parse_path",
@@ -87,7 +87,7 @@ class TestWorkspace(object):
 
         workspace_handler._zip_workspace.assert_not_called()
         workspace_handler._upload.assert_called_once()
-        workspace_handler._upload.assert_called_with(os.path.abspath('foo.zip'), "some_project_id", cluster_id=None)
+        workspace_handler._upload.assert_called_with(os.path.abspath('foo.zip'), "some_project_id")
         assert response_url == 's3://{}/{}'.format(MOCK_BUCKET_NAME, MOCK_OBJECT_KEY)
 
     @mock.patch("gradient.utils.PathParser.parse_path",
@@ -113,5 +113,5 @@ class TestWorkspace(object):
 
         workspace_handler._zip_workspace.assert_not_called()
         workspace_handler._upload.assert_called_once()
-        workspace_handler._upload.assert_called_with(os.path.abspath('foo.zip'), "some_project_id", cluster_id=None)
+        workspace_handler._upload.assert_called_with(os.path.abspath('foo.zip'), "some_project_id")
         assert response_url == 's3://{}/{}'.format(MOCK_BUCKET_NAME, MOCK_OBJECT_KEY)


### PR DESCRIPTION
Reverts Paperspace/gradient-cli#183

Tests are failing for 
ERROR:   py27-pt46-ptc28: commands failed
ERROR:   py35-pt46-ptc28: commands failed
ERROR:   py36-pt46-ptc28: commands failed
ERROR:   py37-pt46-ptc28: commands failed
ERROR:   py38-pt46-ptc28: commands failed