### PR TITLE
output datasets as object array in options file PS-12630

### DIFF
--- a/gradient/cli/common.py
+++ b/gradient/cli/common.py
@@ -76,11 +76,11 @@ class ReadValueFromConfigFile(click.Parameter):
                 option_name = get_option_name(self.opts)
 
                 # Collect all values from objects in the matching object list
-                if (isinstance(self, GradientObjectListOption) and
-                    self.get_object_list_name() in config_data):
+                if isinstance(self, GradientObjectListOption):
                     value_list = []
-                    for objects in config_data[self.get_object_list_name()]:
-                        value_list.append(objects[self.get_object_key()])
+                    if self.get_object_list_name() in config_data:
+                        for object_list_item in config_data[self.get_object_list_name()]:
+                            value_list.append(object_list_item.get(self.get_object_key(), None))
 
                     opts[self.name] = value_list
 

--- a/gradient/cli/common.py
+++ b/gradient/cli/common.py
@@ -159,7 +159,8 @@ def generate_options_template(ctx, param, value):
 
         # If this is an object list type option, add its value list to
         # the specific object list set of value lists.
-        if isinstance(param, GradientObjectListOption):
+        if (isinstance(param, GradientObjectListOption) and
+            option_value is not None):
             object_list_name = param.get_object_list_name()
             if object_list_name not in objects_value_lists:
                 objects_value_lists[object_list_name] = {}

--- a/gradient/cli/common.py
+++ b/gradient/cli/common.py
@@ -73,7 +73,8 @@ class ReadValueFromConfigFile(click.Parameter):
                     self.object_list_name in config_data):
                     value_list = []
                     for object_list_item in config_data[self.object_list_name]:
-                        value_list.append(object_list_item.get(self.object_key)
+                        value_list.append(object_list_item.get(self.object_key))
+
                     if value_list:
                         opts[self.name] = value_list
                 else:

--- a/gradient/cli/common.py
+++ b/gradient/cli/common.py
@@ -62,6 +62,7 @@ def get_option_name(options_strings):
         if opt.startswith("--"):
             return opt[2:]
 
+
 class ReadValueFromConfigFile(click.Parameter):
     def handle_parse_result(self, ctx, opts, args):
         config_file = ctx.params.get(OPTIONS_FILE_PARAMETER_NAME)
@@ -128,6 +129,7 @@ class GradientArgument(ColorExtrasInCommandHelpMixin, ReadValueFromConfigFile, c
 class GradientOption(ColorExtrasInCommandHelpMixin, ReadValueFromConfigFile, click.Option):
     pass
 
+
 api_key_option = click.option(
     "--apiKey",
     "api_key",
@@ -153,9 +155,8 @@ def generate_options_template(ctx, param, value):
         # the specific object list set of value lists.
         if isinstance(param, GradientObjectListOption):
             new_value_list = option_value if option_value is not None else []
-            if param.object_list_name not in objects_value_lists:
-                objects_value_lists[param.object_list_name] = {}
-            value_lists = objects_value_lists[param.object_list_name]
+            object_list_name = param.object_list_name
+            value_lists = objects_value_lists.setdefault(object_list_name, {})
             value_lists[param.object_key] = new_value_list
             continue
 
@@ -174,7 +175,7 @@ def generate_options_template(ctx, param, value):
         object_list = object_lists.setdefault(object_list_name, [])
 
         num_items = max(len(value_list) for value_list in value_lists.values())
-        
+
         for i in range(num_items):
             new_object = {}
             for object_key, value_list in value_lists.items():
@@ -222,7 +223,6 @@ class GradientObjectListOption(GradientOption):
         self.object_name = object_name
         self.object_list_name = self.object_name + "s"
         self.object_key = self._compose_object_key()
-
 
     # Get this option's object key for the objects in the object list
     def _compose_object_key(self):

--- a/gradient/cli/common.py
+++ b/gradient/cli/common.py
@@ -77,14 +77,13 @@ class ReadValueFromConfigFile(click.Parameter):
 
                 # Collect all dataset object keys across all
                 # datasets into a list.
-                if option_name.startswith("dataset"):
+                if ("datasets" in config_data and
+                    option_name.startswith("dataset")):
                     object_key = get_object_key("dataset", option_name)
-                    print("processing " + option_name + " => " + object_key)
                     value_list = []
                     for dataset in config_data["datasets"]:
                         value_list.append(dataset[object_key])
 
-                    print(option_name + self.name + ": ".join(value_list))
                     opts[self.name] = value_list
 
                 else:

--- a/gradient/cli/common.py
+++ b/gradient/cli/common.py
@@ -159,13 +159,13 @@ def generate_options_template(ctx, param, value):
 
         # If this is an object list type option, add its value list to
         # the specific object list set of value lists.
-        if (isinstance(param, GradientObjectListOption) and
-            option_value is not None):
-            object_list_name = param.get_object_list_name()
-            if object_list_name not in objects_value_lists:
-                objects_value_lists[object_list_name] = {}
-            value_lists = objects_value_lists[object_list_name]
-            value_lists[param.get_object_key()] = option_value
+        if isinstance(param, GradientObjectListOption):
+            if option_value is not None:
+                object_list_name = param.get_object_list_name()
+                if object_list_name not in objects_value_lists:
+                    objects_value_lists[object_list_name] = {}
+                value_lists = objects_value_lists[object_list_name]
+                value_lists[param.get_object_key()] = option_value
             continue
 
         if isinstance(param.type, cli_types.ChoiceType):

--- a/gradient/cli/common.py
+++ b/gradient/cli/common.py
@@ -62,11 +62,6 @@ def get_option_name(options_strings):
         if opt.startswith("--"):
             return opt[2:]
 
-def get_object_key(prefix, option_name):
-    object_key = option_name[len(prefix):]
-    object_key = object_key[0].lower() + object_key[1:]
-    return object_key
-
 class ReadValueFromConfigFile(click.Parameter):
     def handle_parse_result(self, ctx, opts, args):
         config_file = ctx.params.get(OPTIONS_FILE_PARAMETER_NAME)
@@ -160,12 +155,12 @@ def generate_options_template(ctx, param, value):
         # If this is an object list type option, add its value list to
         # the specific object list set of value lists.
         if isinstance(param, GradientObjectListOption):
-            if option_value is not None:
-                object_list_name = param.get_object_list_name()
-                if object_list_name not in objects_value_lists:
-                    objects_value_lists[object_list_name] = {}
-                value_lists = objects_value_lists[object_list_name]
-                value_lists[param.get_object_key()] = option_value
+            new_value_list = option_value if option_value is not None else []
+            object_list_name = param.get_object_list_name()
+            if object_list_name not in objects_value_lists:
+                objects_value_lists[object_list_name] = {}
+            value_lists = objects_value_lists[object_list_name]
+            value_lists[param.get_object_key()] = new_value_list
             continue
 
         if isinstance(param.type, cli_types.ChoiceType):
@@ -194,6 +189,8 @@ def generate_options_template(ctx, param, value):
             for object_key, value_list in value_lists.items():
                 if i < len(value_list):
                     new_object[object_key] = value_list[i]
+                else:
+                    new_object[object_key] = None
 
             object_list.append(new_object)
 

--- a/gradient/cli/experiments.py
+++ b/gradient/cli/experiments.py
@@ -170,7 +170,7 @@ def dataset_options(f):
             metavar="<dateset uri>",
             multiple=True,
             help="Url to S3 bucket with dataset",
-            cls=common.GradientOption,
+            cls=common.GradientDatasetOption,
         ),
         click.option(
             "--datasetName",
@@ -178,7 +178,7 @@ def dataset_options(f):
             multiple=True,
             metavar="<dateset name>",
             help="Name of dataset",
-            cls=common.GradientOption,
+            cls=common.GradientDatasetOption,
         ),
         click.option(
             "--datasetAwsAccessKeyId",
@@ -186,14 +186,14 @@ def dataset_options(f):
             multiple=True,
             metavar="<AWS access key>",
             help="S3 bucket's Access Key ID",
-            cls=common.GradientOption,
+            cls=common.GradientDatasetOption,
         ),
         click.option(
             "--datasetAwsSecretAccessKey",
             "dataset_secret_access_key_list",
             multiple=True,
             help="S3 bucket's Secret Access Key",
-            cls=common.GradientOption,
+            cls=common.GradientDatasetOption,
         ),
         click.option(
             "--datasetVersionId",
@@ -201,7 +201,7 @@ def dataset_options(f):
             metavar="<version ID>",
             multiple=True,
             help="S3 dataset's version ID",
-            cls=common.GradientOption,
+            cls=common.GradientDatasetOption,
         ),
         click.option(
             "--datasetEtag",
@@ -209,7 +209,7 @@ def dataset_options(f):
             metavar="<etag>",
             multiple=True,
             help="S3 dataset's ETag",
-            cls=common.GradientOption,
+            cls=common.GradientDatasetOption,
         ),
     ]
     return functools.reduce(lambda x, opt: opt(x), reversed(options), f)

--- a/tests/config_files/experiments_create_multi_node_ds_objs.yaml
+++ b/tests/config_files/experiments_create_multi_node_ds_objs.yaml
@@ -1,0 +1,50 @@
+apiKey: some_key
+artifactDirectory: /artdir
+clusterId: 2a
+datasets:
+- uri: "s3://some.dataset/uri"
+  name: "some dataset name"
+  awsAccessKeyId: none
+  awsSecretAccessKey: none
+  versionId: version1
+  etag: "some etag"
+- uri: "s3://some.other.dataset/uri"
+  name: null
+  awsAccessKeyId: some_other_key_id
+  awsSecretAccessKey: some_other_secret
+  versionId: version2
+  etag: "some other etag"
+experimentEnv:
+  key: val
+experimentType: MPI
+ignoreFiles: file1,file2
+isPreemptible: true
+modelPath: some-model-path
+modelType: some-model-type
+name: multinode_mpi
+masterCommand: ls
+masterContainer: pscon
+masterContainerUser: pscuser
+masterCount: 2
+masterMachineType: psmtype
+masterRegistryPassword: psrpass
+masterRegistryUrl: psrurl
+masterRegistryUsername: psrcus
+ports: '3456'
+projectId: prq70zy79
+vpc: false
+workerCommand: wcom
+workerContainer: wcon
+workerContainerUser: usr
+workerCount: 2
+workerMachineType: mty
+workerRegistryPassword: rpass
+workerRegistryUrl: rurl
+workerRegistryUsername: rusr
+workingDirectory: /dir
+workspace: null
+workspaceUsername: username
+workspacePassword: password
+workspaceArchive: null
+workspaceRef: some_branch_name
+workspaceUrl: wurl

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,11 @@ def create_multi_node_experiment_config_path():
     fixture_dir = p.parent / "config_files" / "experiments_create_multi_node.yaml"
     return str(fixture_dir.resolve())
 
+@pytest.fixture
+def create_multi_node_experiment_ds_objects_config_path():
+    p = Path(__file__)
+    fixture_dir = p.parent / "config_files" / "experiments_create_multi_node_ds_objs.yaml"
+    return str(fixture_dir.resolve())
 
 @pytest.fixture
 def experiment_details_config_path():

--- a/tests/functional/test_experiments.py
+++ b/tests/functional/test_experiments.py
@@ -364,6 +364,310 @@ class TestExperimentsCreateSingleNode(object):
         assert result.exit_code == 0
 
 
+class TestExperimentsCreateMultiNodeDatasetObjects(object):
+    URL = "https://services.paperspace.io/experiments/v1/experiments/"
+    URL_V2 = "https://services.paperspace.io/experiments/v2/experiments/"
+    EXPECTED_HEADERS = http_client.default_headers.copy()
+    EXPECTED_HEADERS_WITH_CHANGED_API_KEY = http_client.default_headers.copy()
+    EXPECTED_HEADERS_WITH_CHANGED_API_KEY["X-API-Key"] = "some_key"
+    BASIC_OPTIONS_COMMAND = [
+        "experiments", "create", "multinode",
+        "--name", "multinode_mpi",
+        "--projectId", "prq70zy79",
+        "--experimentType", "GRPC",
+        "--workerContainer", "wcon",
+        "--workerMachineType", "mty",
+        "--workerCommand", "wcom",
+        "--workerCount", 2,
+        "--parameterServerContainer", "pscon",
+        "--parameterServerMachineType", "psmtype",
+        "--parameterServerCommand", "ls",
+        "--parameterServerCount", 2,
+        "--workerContainerUser", "usr",
+        "--workspace", "https://github.com/Paperspace/gradient-cli.git",
+    ]
+    FULL_OPTIONS_COMMAND = [
+        "experiments", "create", "multinode",
+        "--name", "multinode_mpi",
+        "--ports", 3456,
+        "--workspaceUrl", "wurl",
+        "--workspaceRef", "some_branch_name",
+        "--workspaceUsername", "username",
+        "--workspacePassword", "password",
+        "--workingDirectory", "/dir",
+        "--artifactDirectory", "/artdir",
+        "--clusterId", '2a',
+        "--experimentEnv", '{"key":"val"}',
+        "--projectId", "prq70zy79",
+        "--experimentType", "MPI",
+        "--workerContainer", "wcon",
+        "--workerMachineType", "mty",
+        "--workerCommand", "wcom",
+        "--workerCount", 2,
+        "--masterContainer", "pscon",
+        "--masterMachineType", "psmtype",
+        "--masterCommand", "ls",
+        "--masterCount", 2,
+        "--workerContainerUser", "usr",
+        "--workerRegistryUsername", "rusr",
+        "--workerRegistryPassword", "rpass",
+        "--workerRegistryUrl", "rurl",
+        "--masterContainerUser", "pscuser",
+        "--masterRegistryUsername", "psrcus",
+        "--masterRegistryPassword", "psrpass",
+        "--masterRegistryUrl", "psrurl",
+        "--apiKey", "some_key",
+        "--modelPath", "some-model-path",
+        "--modelType", "some-model-type",
+        "--ignoreFiles", "file1,file2",
+        "--isPreemptible",
+        "--datasetUri", "s3://some.dataset/uri",
+        "--datasetName", "some dataset name",
+        "--datasetAwsAccessKeyId", "none",
+        "--datasetAwsSecretAccessKey", "none",
+        "--datasetVersionId", "version1",
+        "--datasetEtag", "some etag",
+        "--datasetUri", "s3://some.other.dataset/uri",
+        "--datasetName", "none",
+        "--datasetAwsAccessKeyId", "some_other_key_id",
+        "--datasetAwsSecretAccessKey", "some_other_secret",
+        "--datasetVersionId", "version2",
+        "--datasetEtag", "some other etag",
+    ]
+    FULL_OPTIONS_COMMAND_WITH_OPTIONS_FILE = [
+        "experiments", "create", "multinode",
+        "--optionsFile",  # path added in test,
+    ]
+    BASIC_OPTIONS_REQUEST = {
+        u"name": u"multinode_mpi",
+        u"projectHandle": u"prq70zy79",
+        u"experimentTypeId": 2,
+        u"workerContainer": u"wcon",
+        u"workerMachineType": u"mty",
+        u"workerCommand": u"d2NvbQ==",
+        u"workerCount": 2,
+        u"parameterServerContainer": u"pscon",
+        u"parameterServerMachineType": u"psmtype",
+        u"parameterServerCommand": u"bHM=",
+        u"parameterServerCount": 2,
+        u"workerContainerUser": u"usr",
+        u"workspaceUrl": u"https://github.com/Paperspace/gradient-cli.git",
+    }
+    FULL_OPTIONS_REQUEST = {
+        "name": u"multinode_mpi",
+        "ports": "3456",
+        "workspaceUrl": u"wurl",
+        "workspaceRef": "some_branch_name",
+        "workspaceUsername": u"username",
+        "workspacePassword": u"password",
+        "workingDirectory": u"/dir",
+        "artifactDirectory": u"/artdir",
+        "clusterId": '2a',
+        "experimentEnv": {"key": "val"},
+        "projectHandle": "prq70zy79",
+        "experimentTypeId": 3,
+        "workerContainer": u"wcon",
+        "workerMachineType": u"mty",
+        "workerCommand": u"d2NvbQ==",
+        "workerCount": 2,
+        "masterContainer": u"pscon",
+        "masterMachineType": u"psmtype",
+        "masterCommand": u"bHM=",
+        "masterCount": 2,
+        "workerContainerUser": u"usr",
+        "workerRegistryUsername": u"rusr",
+        "workerRegistryPassword": u"rpass",
+        "workerRegistryUrl": u"rurl",
+        "masterContainerUser": u"pscuser",
+        "masterRegistryUsername": u"psrcus",
+        "masterRegistryPassword": u"psrpass",
+        "masterRegistryUrl": u"psrurl",
+        "isPreemptible": True,
+        "modelPath": "some-model-path",
+        "modelType": "some-model-type",
+        "datasets": [
+            {
+                "uri": "s3://some.dataset/uri",
+                "name": "some dataset name",
+                "etag": "some etag",
+                "versionId": "version1",
+            },
+            {
+                "uri": "s3://some.other.dataset/uri",
+                "awsAccessKeyId": "some_other_key_id",
+                "awsSecretAccessKey": "some_other_secret",
+                "etag": "some other etag",
+                "versionId": "version2",
+            },
+        ]
+    }
+    RESPONSE_JSON_200 = {"handle": "sadkfhlskdjh", "message": "success"}
+    RESPONSE_CONTENT_200 = b'{"handle":"sadkfhlskdjh","message":"success"}\n'
+    EXPECTED_STDOUT = "New experiment created with ID: sadkfhlskdjh\n"
+
+    BASIC_OPTIONS_COMMAND_WITH_VPC_SWITCH = [
+        "experiments", "create", "multinode",
+        "--name", "multinode_mpi",
+        "--projectId", "prq70zy79",
+        "--experimentType", "GRPC",
+        "--workerContainer", "wcon",
+        "--workerMachineType", "mty",
+        "--workerCommand", "wcom",
+        "--workerCount", 2,
+        "--parameterServerContainer", "pscon",
+        "--parameterServerMachineType", "psmtype",
+        "--parameterServerCommand", "ls",
+        "--parameterServerCount", 2,
+        "--workerContainerUser", "usr",
+        "--workspace", "https://github.com/Paperspace/gradient-cli.git",
+        "--vpc",
+    ]
+
+
+    @mock.patch("gradient.api_sdk.clients.http_client.requests.post")
+    def test_should_send_proper_data_and_print_message_when_create_experiment_was_run_with_basic_options(self,
+                                                                                                         post_patched):
+        post_patched.return_value = MockResponse(self.RESPONSE_JSON_200, 200, self.RESPONSE_CONTENT_200)
+
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, self.BASIC_OPTIONS_COMMAND)
+
+        assert self.EXPECTED_STDOUT in result.output, result.exc_info
+        post_patched.assert_called_once_with(self.URL,
+                                             headers=self.EXPECTED_HEADERS,
+                                             json=self.BASIC_OPTIONS_REQUEST,
+                                             params=None,
+                                             files=None,
+                                             data=None)
+        assert result.exit_code == 0
+
+    @mock.patch("gradient.api_sdk.clients.http_client.requests.post")
+    def test_should_read_options_from_config_file(
+            self, post_patched, create_multi_node_experiment_ds_objects_config_path):
+        post_patched.return_value = MockResponse(self.RESPONSE_JSON_200, 200, self.RESPONSE_CONTENT_200)
+        command = self.FULL_OPTIONS_COMMAND_WITH_OPTIONS_FILE[:] + [create_multi_node_experiment_ds_objects_config_path]
+
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, command)
+
+        assert self.EXPECTED_STDOUT in result.output, result.exc_info
+        post_patched.assert_called_once_with(self.URL,
+                                             headers=self.EXPECTED_HEADERS_WITH_CHANGED_API_KEY,
+                                             json=self.FULL_OPTIONS_REQUEST,
+                                             params=None,
+                                             files=None,
+                                             data=None)
+        assert result.exit_code == 0
+
+    @mock.patch("gradient.api_sdk.clients.http_client.requests.post")
+    def test_should_send_proper_data_and_print_message_when_create_experiment_was_run_with_full_options(self,
+                                                                                                        post_patched):
+        post_patched.return_value = MockResponse(self.RESPONSE_JSON_200, 200, self.RESPONSE_CONTENT_200)
+
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, self.FULL_OPTIONS_COMMAND)
+
+        post_patched.assert_called_once_with(self.URL,
+                                             headers=self.EXPECTED_HEADERS_WITH_CHANGED_API_KEY,
+                                             json=self.FULL_OPTIONS_REQUEST,
+                                             params=None,
+                                             files=None,
+                                             data=None)
+        assert self.EXPECTED_STDOUT in result.output
+        assert result.exit_code == 0
+
+    @mock.patch("gradient.api_sdk.clients.http_client.requests.post")
+    def test_should_send_data_to_v2_url_when_vpc_switch_was_used(self, post_patched):
+        post_patched.return_value = MockResponse(self.RESPONSE_JSON_200, 200, self.RESPONSE_CONTENT_200)
+
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, self.BASIC_OPTIONS_COMMAND_WITH_VPC_SWITCH)
+
+        assert self.EXPECTED_STDOUT in result.output, result.exc_info
+
+        post_patched.assert_called_once_with(self.URL_V2,
+                                             headers=self.EXPECTED_HEADERS,
+                                             json=self.BASIC_OPTIONS_REQUEST,
+                                             params=None,
+                                             files=None,
+                                             data=None)
+        assert result.exit_code == 0
+
+    @mock.patch("gradient.commands.experiments.TensorboardHandler")
+    @mock.patch("gradient.api_sdk.clients.http_client.requests.post")
+    def test_should_use_tensorboard_handler_with_true_value_when_tensorboard_option_was_used_without_value(
+            self, post_patched, tensorboard_handler_class):
+        post_patched.return_value = MockResponse(self.RESPONSE_JSON_200)
+        command = self.FULL_OPTIONS_COMMAND[:] + ["--tensorboard=some_tensorboard_id"]
+        tensorboard_handler = mock.MagicMock()
+        tensorboard_handler_class.return_value = tensorboard_handler
+
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, command)
+
+        assert self.EXPECTED_STDOUT in result.output, result.exc_info
+        post_patched.assert_called_once_with(self.URL,
+                                             headers=self.EXPECTED_HEADERS_WITH_CHANGED_API_KEY,
+                                             json=self.FULL_OPTIONS_REQUEST,
+                                             params=None,
+                                             files=None,
+                                             data=None)
+        assert result.exit_code == 0
+        assert self.EXPECTED_HEADERS_WITH_CHANGED_API_KEY["X-API-Key"] == "some_key"
+
+        tensorboard_handler_class.assert_called_once_with("some_key")
+        tensorboard_handler.maybe_add_to_tensorboard.assert_called_once_with("some_tensorboard_id", "sadkfhlskdjh")
+
+    @mock.patch("gradient.commands.experiments.TensorboardHandler")
+    @mock.patch("gradient.api_sdk.clients.http_client.requests.post")
+    def test_should_use_tensorboard_handler_with_tb_id_when_tensorboard_option_was_used_with_tb_id(
+            self, post_patched, tensorboard_handler_class):
+        post_patched.return_value = MockResponse(self.RESPONSE_JSON_200)
+        command = self.FULL_OPTIONS_COMMAND[:] + ["--tensorboard"]
+        tensorboard_handler = mock.MagicMock()
+        tensorboard_handler_class.return_value = tensorboard_handler
+
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, command)
+
+        assert self.EXPECTED_STDOUT in result.output, result.exc_info
+        post_patched.assert_called_once_with(self.URL,
+                                             headers=self.EXPECTED_HEADERS_WITH_CHANGED_API_KEY,
+                                             json=self.FULL_OPTIONS_REQUEST,
+                                             params=None,
+                                             files=None,
+                                             data=None)
+        assert result.exit_code == 0
+        assert self.EXPECTED_HEADERS_WITH_CHANGED_API_KEY["X-API-Key"] == "some_key"
+
+        tensorboard_handler_class.assert_called_once_with("some_key")
+        tensorboard_handler.maybe_add_to_tensorboard.assert_called_once_with(True, "sadkfhlskdjh")
+
+    @mock.patch("gradient.commands.experiments.TensorboardHandler")
+    @mock.patch("gradient.api_sdk.clients.http_client.requests.post")
+    def test_should_send_proper_data_and_print_message_when_create_experiment_was_run_with_full_options(
+            self, post_patched, tensorboard_handler_class):
+        post_patched.return_value = MockResponse(self.RESPONSE_JSON_200)
+        command = self.FULL_OPTIONS_COMMAND[:] + ["--tensorboard"]
+        tensorboard_handler = mock.MagicMock()
+        tensorboard_handler_class.return_value = tensorboard_handler
+
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, command)
+
+        assert self.EXPECTED_STDOUT in result.output, result.exc_info
+        post_patched.assert_called_once_with(self.URL,
+                                             headers=self.EXPECTED_HEADERS_WITH_CHANGED_API_KEY,
+                                             json=self.FULL_OPTIONS_REQUEST,
+                                             params=None,
+                                             files=None,
+                                             data=None)
+        assert result.exit_code == 0
+        assert self.EXPECTED_HEADERS_WITH_CHANGED_API_KEY["X-API-Key"] == "some_key"
+
+        tensorboard_handler_class.assert_called_once_with("some_key")
+        tensorboard_handler.maybe_add_to_tensorboard.assert_called_once_with(True, "sadkfhlskdjh")
+
 class TestExperimentsCreateMultiNode(object):
     URL = "https://services.paperspace.io/experiments/v1/experiments/"
     URL_V2 = "https://services.paperspace.io/experiments/v2/experiments/"


### PR DESCRIPTION
When using the --createOptionsFile, output datasets as
an array of dataset objects rather than parallel dataset
option lists.