### PR TITLE
Make --workspace optional again for VPC experiments

### DIFF
--- a/gradient/commands/experiments.py
+++ b/gradient/commands/experiments.py
@@ -108,9 +108,6 @@ class BaseCreateExperimentCommandMixin(object):
     def _handle_workspace(self, instance_dict):
         handler = self.workspace_handler.handle(instance_dict)
 
-        if (instance_dict.get("cluster_id") or instance_dict.get("use_vpc")) and handler.lower() == "none":
-            raise click.UsageError('Missing option "--workspace" is required for VPC experiments')
-
         instance_dict.pop("ignore_files", None)
         instance_dict.pop("workspace", None)
         instance_dict.pop("workspace_archive", None)


### PR DESCRIPTION
Can't verify the prod api is ready for this at the moment