### PR TITLE
Revert "Add gradient-utils to required"

### DIFF
--- a/gradient/__init__.py
+++ b/gradient/__init__.py
@@ -1,4 +1,1 @@
-# noinspection PyUnresolvedReferences
-from gradient_utils import *
-
 from .api_sdk import *

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,7 @@ setup(
         'attrs<=19',
         'PyYAML==5.*',
         'python-dateutil==2.*',
-        'websocket-client==0.57.*',
-        'gradient-utils>=0.1.1',
+        'websocket-client==0.57.*'
     ],
     entry_points={'console_scripts': [
         'gradient = gradient:main.main',


### PR DESCRIPTION
Revert the addition of gradient-utils for now so we can fix the build.

This dependency seems pretty heavy for the cli (it pulls in pymongo, networkx, numpy, etc...). We should decided if it is really needed.