### PR TITLE
chore: automate pre-releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,9 @@ jobs:
             if [ -n "$CIRCLE_TAG" ]; then
               VERSION="$CIRCLE_TAG"
             else
+              # CIRCLE_PR_NUMBER is only set on fork prs
               PR_NUMBER="${CIRCLE_PULL_REQUEST#"https://github.com/Paperspace/gradient-cli/pull/"}"
-              VERSION="0.0.0.post${CIRCLE_PR_NUMBER}.dev${CIRCLE_BUILD_NUM}"
+              VERSION="0.0.0.post${PR_NUMBER}.dev${CIRCLE_BUILD_NUM}"
             fi
             echo "Publishing version $VERSION"
             echo "version = \"${VERSION}\"" > gradient/version.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,10 +55,12 @@ jobs:
           name: Make version.py
           command: |
             if [ -n "$CIRCLE_TAG" ]; then
-              echo "version = \"$CIRCLE_TAG\"" > gradient/version.py
+              VERSION="$CIRCLE_TAG"
             else
-              echo "version = \"0.0.0.post${CIRCLE_PR_NUMBER}.dev${CIRCLE_BUILD_NUM}\"" > gradient/version.py
+              VERSION="0.0.0.post${CIRCLE_PR_NUMBER}.dev${CIRCLE_BUILD_NUM}"
             fi
+            echo "Publishing version $VERSION"
+            echo "version = \"${VERSION}\"" > gradient/version.py
       - run:
           name: import GPG key
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
             if [ -n "$CIRCLE_TAG" ]; then
               VERSION="$CIRCLE_TAG"
             else
+              PR_NUMBER="${CIRCLE_PULL_REQUEST#"https://github.com/Paperspace/gradient-cli/pull/"}"
               VERSION="0.0.0.post${CIRCLE_PR_NUMBER}.dev${CIRCLE_BUILD_NUM}"
             fi
             echo "Publishing version $VERSION"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,18 +2,11 @@ version: 2.1
 workflows:
   build_and_deploy:
     jobs:
-      - test:
-          filters:
-            tags:
-              only: /.*/
+      - test
       - deploy:
           requires:
             - test
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
+
 executors:
   python-tox:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,34 @@
 version: 2.1
 workflows:
-  build_and_deploy:
+  master:
     jobs:
-      - test
+      - test:
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/
       - deploy:
           requires:
             - test
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+
+  pr:
+    jobs:
+      - test:
+          filters:
+            branches:
+              ignore: master
+      - deploy:
+          requires:
+            - test
+          filters:
+            branches:
+              ignore: master
 
 executors:
   python-tox:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,14 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Make version.py
+          command: |
+            if [ -n "$CIRCLE_TAG" ]; then
+              echo "version = \"$CIRCLE_TAG\"" > gradient/version.py
+            else
+              echo "version = \"0.0.0.post${CIRCLE_PR_NUMBER}.dev${CIRCLE_BUILD_NUM}\"" > gradient/version.py
+            fi
+      - run:
           name: import GPG key
           command: |
             export GPG_TTY=$(tty)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
             else
               # CIRCLE_PR_NUMBER is only set on fork prs
               PR_NUMBER="${CIRCLE_PULL_REQUEST#"https://github.com/Paperspace/gradient-cli/pull/"}"
-              VERSION="0.0.0.post${PR_NUMBER}.dev${CIRCLE_BUILD_NUM}"
+              VERSION="0.0.0.a${PR_NUMBER}.dev${CIRCLE_BUILD_NUM}"
             fi
             echo "Publishing version $VERSION"
             echo "version = \"${VERSION}\"" > gradient/version.py

--- a/gradient/version.py
+++ b/gradient/version.py
@@ -1,1 +1,1 @@
-version = "0.9.1a5"
+version = "0.0.0"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class VerifyVersionCommand(install):
     description = 'verify that version is set'
 
     def run(self):
-        if version == '0.0.0'
+        if version == '0.0.0':
             sys.exit("No version set")
 
 
@@ -94,5 +94,8 @@ setup(
             'sphinx-click',
             'recommonmark'
         ],
+    },
+    cmdclass={
+        'verify': VerifyVersionCommand,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -7,16 +7,8 @@ from codecs import open
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-with io.open("gradient/version.py", "w", encoding="utf8") as f:
-    tag = os.getenv('CIRCLE_TAG')
-    build = os.getenv('CIRCLE_BUILD_NUM')
-    pr = os.getenv('CIRCLE_PR_NUMBER')
-    if pr:
-        version = "0.0.0.post{}.dev{}".format(pr, build)
-    else:
-        version = tag
-
-    f.write(u"version = {}".format(version))
+with io.open("gradient/version.py", "rt", encoding="utf8") as f:
+    version = re.search(r"version = \"(.*?)\"", f.read()).group(1)
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -31,12 +23,12 @@ except(IOError, ImportError, OSError):
 
 
 class VerifyVersionCommand(install):
-    """Custom command to verify the version"""
-    description = 'verify that version is set'
+    """Custom command to verify that the git tag matches our version"""
+    description = 'verify that the git tag matches our version'
 
     def run(self):
-        if version == '0.0.0':
-            sys.exit("No version set")
+        if '0.0.0' == version:
+            sys.exit("Version unspecified")
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,16 @@ from codecs import open
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-with io.open("gradient/version.py", "rt", encoding="utf8") as f:
-    version = re.search(r"version = \"(.*?)\"", f.read()).group(1)
+with io.open("gradient/version.py", "w", encoding="utf8") as f:
+    tag = os.getenv('CIRCLE_TAG')
+    build = os.getenv('CIRCLE_BUILD_NUM')
+    pr = os.getenv('CIRCLE_PR_NUMBER')
+    if pr:
+        version = "0.0.0.post{}.dev{}".format(pr, build)
+    else:
+        version = tag
+
+    f.write("version = {}".format(version))
 
 here = os.path.abspath(os.path.dirname(__file__))
 
@@ -23,17 +31,12 @@ except(IOError, ImportError, OSError):
 
 
 class VerifyVersionCommand(install):
-    """Custom command to verify that the git tag matches our version"""
-    description = 'verify that the git tag matches our version'
+    """Custom command to verify the version"""
+    description = 'verify that version is set'
 
     def run(self):
-        tag = os.getenv('CIRCLE_TAG')
-
-        if tag != version:
-            info = "Git tag: {0} does not match the version of this app: {1}".format(
-                tag, version
-            )
-            sys.exit(info)
+        if version == '0.0.0'
+            sys.exit("No version set")
 
 
 setup(
@@ -91,8 +94,5 @@ setup(
             'sphinx-click',
             'recommonmark'
         ],
-    },
-    cmdclass={
-        'verify': VerifyVersionCommand,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with io.open("gradient/version.py", "w", encoding="utf8") as f:
     else:
         version = tag
 
-    f.write("version = {}".format(version))
+    f.write(u"version = {}".format(version))
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Pre-release packages for testing by tal are released as `0.0.0.a${PR_NUM}.dev${BUILD_NUM}`. Installed by `pip uninstall -U gradient && pip install 'gradient==0.0.0.a${PR_NUM}.dev${BUILD_NUM}' --pre -U`. The version can be obtained from the build logs