### PR TITLE
feat(notebooks): require projectId to fork notebook N-39

### DIFF
--- a/gradient/api_sdk/clients/notebook_client.py
+++ b/gradient/api_sdk/clients/notebook_client.py
@@ -122,16 +122,17 @@ class NotebooksClient(TagsSupportMixin, BaseClient):
 
         return handle
 
-    def fork(self, id, tags=None):
+    def fork(self, id, project_id, tags=None):
         """Fork an existing notebook
         :param str|int id:
+        :param str project_id:
         :param list[str] tags: List of tags
 
         :return: Notebook ID
         :rtype str:
         """
         repository = self.build_repository(repositories.ForkNotebook)
-        handle = repository.fork(id)
+        handle = repository.fork(id, project_id)
 
         if tags:
             self.add_tags(entity_id=handle, tags=tags)

--- a/gradient/api_sdk/repositories/notebooks.py
+++ b/gradient/api_sdk/repositories/notebooks.py
@@ -37,8 +37,8 @@ class ForkNotebook(GetNotebookApiUrlMixin, BaseRepository):
     SERIALIZER_CLS = serializers.NotebookSchema
     VALIDATION_ERROR_MESSAGE = "Failed to fork notebook"
 
-    def fork(self, id):
-        instance = {"notebookId": id}
+    def fork(self, id_, project_id):
+        instance = {"notebookId": id_, "projectId": project_id}
         handle = self._send_request(instance)
         return handle
 

--- a/gradient/cli/notebooks.py
+++ b/gradient/cli/notebooks.py
@@ -237,14 +237,23 @@ def start_notebook(api_key, options_file, **notebook):
 @click.option(
     "--id",
     "id_",
+    required=True,
     help="Notebook ID",
+    cls=common.GradientOption,
+)
+@click.option(
+    "--projectId",
+    "project_id",
+    required=True,
+    type=str,
+    help="Project ID",
     cls=common.GradientOption,
 )
 @common.api_key_option
 @common.options_file
-def delete_notebook(id_, api_key, options_file):
+def fork_notebook(id_, project_id, api_key, options_file):
     command = notebooks.ForkNotebookCommand(api_key=api_key)
-    command.execute(id_=id_)
+    command.execute(id_=id_, project_id=project_id)
 
 
 @notebooks_group.command("delete", help="Delete existing notebook")

--- a/gradient/commands/notebooks.py
+++ b/gradient/commands/notebooks.py
@@ -69,9 +69,9 @@ class StartNotebookCommand(BaseNotebookCommand):
 class ForkNotebookCommand(BaseNotebookCommand):
     WAITING_FOR_RESPONSE_MESSAGE = "Forking notebook"
 
-    def execute(self, id_):
+    def execute(self, id_, project_id):
         with halo.Halo(text=self.WAITING_FOR_RESPONSE_MESSAGE, spinner="dots"):
-            handle = self.client.fork(id_)
+            handle = self.client.fork(id_, project_id)
 
         self.logger.log("Notebook forked to id: {}".format(handle))
 

--- a/gradient/commands/notebooks.py
+++ b/gradient/commands/notebooks.py
@@ -120,6 +120,7 @@ class ShowNotebookDetailsCommand(DetailsCommandMixin, BaseNotebookCommand):
         data = (
             ("Name", instance.name),
             ("ID", instance.id),
+            ("Project", instance.project_handle),
             ("VM Type", instance.vm_type),
             ("State", instance.state),
             ("FQDN", instance.fqdn),

--- a/tests/functional/test_notebooks.py
+++ b/tests/functional/test_notebooks.py
@@ -234,9 +234,11 @@ class TestNotebooksFork(object):
         "notebooks",
         "fork",
         "--id", "n1234",
+        "--projectId", "p1234",
     ]
     EXPECTED_REQUEST_JSON = {
         "notebookId": "n1234",
+        "projectId": "p1234",
     }
     EXPECTED_RESPONSE_JSON = {
         "handle": "n1234",
@@ -251,6 +253,7 @@ class TestNotebooksFork(object):
         "notebooks",
         "fork",
         "--id", "n1234",
+        "--projectId", "p1234",
         "--apiKey", "some_key",
     ]
     RESPONSE_JSON_WITH_WRONG_API_TOKEN = {"status": 400, "message": "Invalid API token"}

--- a/tests/functional/test_notebooks.py
+++ b/tests/functional/test_notebooks.py
@@ -648,6 +648,7 @@ class TestNotebooksdetails(object):
 | Name    | some_name                         |
 +---------+-----------------------------------+
 | ID      | ngw7piq9                          |
+| Project | prg284tu2                         |
 | VM Type | K80                               |
 | State   | Running                           |
 | FQDN    | ngw7piq9.dgradient.paperspace.com |
@@ -658,6 +659,7 @@ class TestNotebooksdetails(object):
 | Name    | some_name                         |
 +---------+-----------------------------------+
 | ID      | ngw7piq9                          |
+| Project | prg284tu2                         |
 | VM Type | K80                               |
 | State   | Running                           |
 | FQDN    | ngw7piq9.dgradient.paperspace.com |


### PR DESCRIPTION
https://linear.app/paperspace/issue/N-39/make-projectid-a-required-parameter-to-fork-in-the-cli

QA test plan:
1) try to fork a notebook without a projectId and fail 😿 
2) create a project, note id
3) try to fork a notebook with projectId and succeed 😸 
4) confirm that the notebook is in fact in that project via `notebooks details`