### PR TITLE
fix(metrics): get command relax validation to allow any --metric

### DIFF
--- a/gradient/cli/deployments.py
+++ b/gradient/cli/deployments.py
@@ -705,7 +705,7 @@ def deployment_remove_tags(id, options_file, api_key, **kwargs):
     multiple=True,
     type=str,
     default=(constants.BuiltinMetrics.cpu_percentage, constants.BuiltinMetrics.memory_usage),
-    help="One or more metrics that you want to read. Defaults to cpuPercentage and memoryUsage",
+    help=("One or more metrics that you want to read: {}. Defaults to cpuPercentage and memoryUsage. To view available custom metrics, use command: `gradient deployments metrics list`".format(', '.join(map(str, constants.METRICS_MAP)))),
     cls=common.GradientOption,
 )
 @click.option(

--- a/gradient/cli/deployments.py
+++ b/gradient/cli/deployments.py
@@ -703,7 +703,7 @@ def deployment_remove_tags(id, options_file, api_key, **kwargs):
     "--metric",
     "metrics_list",
     multiple=True,
-    type=ChoiceType(constants.METRICS_MAP, case_sensitive=False),
+    type=str,
     default=(constants.BuiltinMetrics.cpu_percentage, constants.BuiltinMetrics.memory_usage),
     help="One or more metrics that you want to read. Defaults to cpuPercentage and memoryUsage",
     cls=common.GradientOption,

--- a/gradient/cli/experiments.py
+++ b/gradient/cli/experiments.py
@@ -861,7 +861,7 @@ def experiment_remove_tags(id, options_file, api_key, **kwargs):
     "--metric",
     "metrics_list",
     multiple=True,
-    type=ChoiceType(constants.METRICS_MAP, case_sensitive=False),
+    type=str,
     default=(constants.BuiltinMetrics.cpu_percentage, constants.BuiltinMetrics.memory_usage),
     help="One or more metrics that you want to read. Defaults to cpuPercentage and memoryUsage",
     cls=common.GradientOption,

--- a/gradient/cli/experiments.py
+++ b/gradient/cli/experiments.py
@@ -863,7 +863,7 @@ def experiment_remove_tags(id, options_file, api_key, **kwargs):
     multiple=True,
     type=str,
     default=(constants.BuiltinMetrics.cpu_percentage, constants.BuiltinMetrics.memory_usage),
-    help=("One or more metrics that you want to read. Defaults to cpuPercentage and memoryUsage. Custom metrics are {}".format("hello")), # TODO replace "hello" with custom metrics
+    help=("One or more metrics that you want to read: {}. Defaults to cpuPercentage and memoryUsage. To view available custom metrics, use command: `gradient experiments metrics list`".format(', '.join(map(str, constants.METRICS_MAP)))),
     cls=common.GradientOption,
 )
 @click.option(

--- a/gradient/cli/experiments.py
+++ b/gradient/cli/experiments.py
@@ -863,7 +863,7 @@ def experiment_remove_tags(id, options_file, api_key, **kwargs):
     multiple=True,
     type=str,
     default=(constants.BuiltinMetrics.cpu_percentage, constants.BuiltinMetrics.memory_usage),
-    help="One or more metrics that you want to read. Defaults to cpuPercentage and memoryUsage",
+    help=("One or more metrics that you want to read. Defaults to cpuPercentage and memoryUsage. Custom metrics are {}".format("hello")), # TODO replace "hello" with custom metrics
     cls=common.GradientOption,
 )
 @click.option(

--- a/gradient/cli/jobs.py
+++ b/gradient/cli/jobs.py
@@ -533,7 +533,7 @@ def job_remove_tags(id, options_file, api_key, **kwargs):
     "--metric",
     "metrics_list",
     multiple=True,
-    type=ChoiceType(constants.METRICS_MAP, case_sensitive=False),
+    type=str,
     default=(constants.BuiltinMetrics.cpu_percentage, constants.BuiltinMetrics.memory_usage),
     help="One or more metrics that you want to read. Defaults to cpuPercentage and memoryUsage",
     cls=common.GradientOption,

--- a/gradient/cli/jobs.py
+++ b/gradient/cli/jobs.py
@@ -535,7 +535,7 @@ def job_remove_tags(id, options_file, api_key, **kwargs):
     multiple=True,
     type=str,
     default=(constants.BuiltinMetrics.cpu_percentage, constants.BuiltinMetrics.memory_usage),
-    help="One or more metrics that you want to read. Defaults to cpuPercentage and memoryUsage",
+    help=("One or more metrics that you want to read: {}. Defaults to cpuPercentage and memoryUsage. To view available custom metrics, use command: `gradient jobs metrics list`".format(', '.join(map(str, constants.METRICS_MAP)))),
     cls=common.GradientOption,
 )
 @click.option(

--- a/gradient/cli/notebooks.py
+++ b/gradient/cli/notebooks.py
@@ -383,7 +383,7 @@ def notebook_remove_tags(id, options_file, api_key, **kwargs):
     multiple=True,
     type=str,
     default=(constants.BuiltinMetrics.cpu_percentage, constants.BuiltinMetrics.memory_usage),
-    help="One or more metrics that you want to read. Defaults to cpuPercentage and memoryUsage",
+    help=("One or more metrics that you want to read: {}. Defaults to cpuPercentage and memoryUsage. To view available custom metrics, use command: `gradient notebooks metrics list`".format(', '.join(map(str, constants.METRICS_MAP)))),
     cls=common.GradientOption,
 )
 @click.option(

--- a/gradient/cli/notebooks.py
+++ b/gradient/cli/notebooks.py
@@ -381,7 +381,7 @@ def notebook_remove_tags(id, options_file, api_key, **kwargs):
     "--metric",
     "metrics_list",
     multiple=True,
-    type=ChoiceType(constants.METRICS_MAP, case_sensitive=False),
+    type=str,
     default=(constants.BuiltinMetrics.cpu_percentage, constants.BuiltinMetrics.memory_usage),
     help="One or more metrics that you want to read. Defaults to cpuPercentage and memoryUsage",
     cls=common.GradientOption,


### PR DESCRIPTION
Currently we're only allowing get metrics for this hard coded list of options `cpuPercentage, memoryUsage, gpuMemoryFree, gpuMemoryUsed, gpuPowerDraw, gpuTemp, gpuUtilization, gpuMemoryUtilization`. if user inputs anything other than those options, the cli will raise an error. we want to relax this validation to support custom metrics

We also want to show known metrics in the --help text

QA plan: 
1. Try getting custom metric for deployments, run command `gradient deployments metrics get --id desmvfs1gxebznb --metric iamcustom`, should return null instead of showing an error
2. Run command `gradient deployments metrics --help`, check if the `get` command help text now mentions `cpuPercentage, memoryUsage, gpuMemoryFree, gpuMemoryUsed, gpuPowerDraw, gpuTemp, gpuUtilization, gpuMemoryUtilization`
3. Repeat 1 & 2 for jobs, experiments, and notebooks