### PR TITLE
fix(dataset-importer): add support for s3 endpoint urls

### DIFF
--- a/gradient/cli/datasets.py
+++ b/gradient/cli/datasets.py
@@ -180,7 +180,7 @@ def update_dataset(
 @click.option(
     "--httpUrl",
     "http_url",
-    help="HTTP/S URL https://data.something.org/all_my_data.zip}}",
+    help="HTTP/S URL https://data.something.org/all_my_data.zip",
     cls=common.GradientOption,
 )
 @click.option(

--- a/gradient/commands/datasets.py
+++ b/gradient/commands/datasets.py
@@ -708,12 +708,7 @@ class ImportDatasetCommand(BaseCreateJobCommandMixin, BaseJobCommand):
         command = "%s %s /data/output" % (IMPORTER_COMMAND, (s3_url or http_url))
         if s3_url:
             if AWS_HOST in s3_url:
-                striped_url = s3_url
-                if "http://" in striped_url:
-                    striped_url = s3_url.replace('http://', "")
-                if "https://" in striped_url:
-                    striped_url = s3_url.replace('https://', "")
-
+                striped_url = s3_url.replace('http://', "").replace('https://', "")
                 command = "%s %s /data/output" % (IMPORTER_COMMAND, striped_url)
             else:
                 command = "%s s3::%s /data/output" % (IMPORTER_COMMAND, s3_url)

--- a/gradient/commands/datasets.py
+++ b/gradient/commands/datasets.py
@@ -722,9 +722,6 @@ class ImportDatasetCommand(BaseCreateJobCommandMixin, BaseJobCommand):
     
     def get_env_vars(self, s3_url, http_url, secrets):
         if s3_url is not None:
-            if secrets[S3_ACCESS_KEY] is None or secrets[S3_SECRET_KEY] is None:
-                self.logger.log('s3AccessKey and s3SecretKey required')
-                return 
 
             access_key_secret = self.create_secret(S3_ACCESS_KEY, secrets[S3_ACCESS_KEY])
             secret_key_secret = self.create_secret(S3_SECRET_KEY, secrets[S3_SECRET_KEY])
@@ -757,6 +754,9 @@ class ImportDatasetCommand(BaseCreateJobCommandMixin, BaseJobCommand):
         if s3_url is None and http_url is None:
             self.logger.log('Error: --s3Url or --httpUrl required')
             return
+        if s3_url and access_key is None or secret_key is None:
+            self.logger.log('Error: s3AccessKey and s3SecretKey required for s3')
+            return 
 
         workflow = {
             "cluster_id": cluster_id,


### PR DESCRIPTION
This PR now strips amazon s3 URL's of https:// and s3 protocol to support downloads with go-getter library and adds a progress bar for user logs

QA Test Plan
Set PAPERSPACE_CONFIG_HOST environment variable to point to staging
`export PAPERSPACE_CONFIG_HOST=https://staging-api.paperspace.io`

Create dataset
Staging Google Saml Prod storage provider id: `sp694axp9oevzyj`
`python3 ./gradient datasets create --name <NAME> --storageProviderId <STORAGE PROVIDER ID>`

```
python3 ./gradient datasets import \
--clusterId clcjo828k \
--machineType c5.xlarge \
--datasetId dsr4bvtdcsefhgq \
--s3Url https://mnist-datasets.s3.amazonaws.com/public/mnist-images.zip \
--s3AccessKey ACCESS_KEY \
--s3SecretKey SECRET
```

```
python3 ./gradient datasets import \
--clusterId clcjo828k \
--machineType c5.xlarge \
--datasetId dsr4bvtdcsefhgq \
--s3Url https://chris1.nyc3.digitaloceanspaces.com/folder/image0-3.jpg
```


