### PR TITLE
fix(docker): pin dockerfile's gradient-sdk version to 1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir gradient
+    pip install --no-cache-dir gradient==1.5.0
 
 ENV PAPERSPACE_API_KEY your_api_key_value
 ENV PAPERSPACE_WEB_URL https://console.paperspace.com


### PR DESCRIPTION
Since it wasn't pinned it was installing 1.4.5 and can result in versions updating inadvertently. 