### PR TITLE
fix(circle): run build_and_push in a new dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
           context: docker-deploy
           docker_username: ${DOCKER_USERNAME}
           docker_password: ${DOCKER_PASSWORD}
-          workspace_root: *workspace_root
+          workspace_root: /tmp/build_and_push_latest
           docker_image: *docker_image
           docker_tag: latest
           filters:


### PR DESCRIPTION
This error was showing up in builds 
```
Directory (.) you are trying to checkout to is not empty and not a git repository
```