### PR TITLE
fix(models): require model download params pla-158

### DIFF
--- a/gradient/cli/models.py
+++ b/gradient/cli/models.py
@@ -126,6 +126,7 @@ def create_model(api_key, options_file, **model):
 @models_group.command("upload", help="Upload a model file or directory")
 @click.argument(
     "PATH",
+    required=True,
     type=click.Path(exists=True),
     cls=common.GradientArgument,
 )

--- a/gradient/cli/models.py
+++ b/gradient/cli/models.py
@@ -216,6 +216,7 @@ def model_details(model_id, api_key, options_file):
 @click.option(
     "--destinationDir",
     "destination_directory",
+    required=True,
     help="Destination directory",
     cls=common.GradientOption,
 )


### PR DESCRIPTION
these fields are required to download a model from the CLI :-)
straightforward PR and more of a sanity-check that these 3 actions still work in the CLI

QA: confirm that you can download 3 types of models from the CLI:
- [x] dataset-backed model (created by using the create-model action in a workflow)
- [x] web-uploaded model
- [x] CLI-uploaded model
- this last upload should also work but may include the model file(s) in a nested directory structure - this is ok bc we will be retiring this method.  but confirm the rest of the download actions only download the model file(s) as expected