### PR TITLE
fix(workflows): display log id of a started workflow PLA-374

### DIFF
--- a/gradient/commands/workflows.py
+++ b/gradient/commands/workflows.py
@@ -77,6 +77,10 @@ class CreateWorkflowRunCommand(BaseWorkflowCommand):
 
         workflow = self.client.run_workflow(
             spec=spec, inputs=inputs, workflow_id=workflow_id, cluster_id=cluster_id)
+
+        logId = workflow.get('status', {}).get('logId')
+        if logId is not None:
+            self.logger.log("Created workflow run %s", logId)
         return workflow
 
 

--- a/gradient/commands/workflows.py
+++ b/gradient/commands/workflows.py
@@ -80,7 +80,7 @@ class CreateWorkflowRunCommand(BaseWorkflowCommand):
 
         logId = workflow.get('status', {}).get('logId')
         if logId is not None:
-            self.logger.log("Created workflow run %s", logId)
+            self.logger.log("Created workflow run {}".format(logId))
         return workflow
 
 


### PR DESCRIPTION
QA test plan:

- [x] start a workflow, the log id should be printed to the console as part of the `workflow run` command. Feed this log id into the logs command.