### PR TITLE
fix(notebooks): remove --name from `gradient notebooks start` command

### DIFF
--- a/gradient/api_sdk/clients/notebook_client.py
+++ b/gradient/api_sdk/clients/notebook_client.py
@@ -87,7 +87,6 @@ class NotebooksClient(TagsSupportMixin, BaseClient):
             id,
             machine_type,
             cluster_id=None,
-            name=None,
             shutdown_timeout=None,
             is_preemptible=None,
             tags=None,
@@ -108,7 +107,6 @@ class NotebooksClient(TagsSupportMixin, BaseClient):
             notebook_id=id,
             machine_type=machine_type,
             cluster_id=cluster_id,
-            notebook_name=name,
             shutdown_timeout=shutdown_timeout,
             is_preemptible=is_preemptible,
         )

--- a/gradient/api_sdk/models/notebook.py
+++ b/gradient/api_sdk/models/notebook.py
@@ -72,5 +72,4 @@ class NotebookStart(object):
     cluster_id = attr.ib(type=str, default=None)
     shutdown_timeout = attr.ib(type=int, default=None)
     is_preemptible = attr.ib(type=bool, default=None)
-    notebook_name = attr.ib(type=str, default=None)
 

--- a/gradient/cli/notebooks.py
+++ b/gradient/cli/notebooks.py
@@ -191,13 +191,6 @@ def create_notebook(api_key, options_file, **notebook):
     cls=common.GradientOption,
 )
 @click.option(
-    "--name",
-    "name",
-    type=str,
-    help="Notebook name",
-    cls=common.GradientOption,
-)
-@click.option(
     "--shutdownTimeout",
     "shutdown_timeout",
     help="Shutdown timeout in hours",


### PR DESCRIPTION
Tested against psdev, created a notebook in the UI, stopped it, ran
```bash
python3 -m gradient notebooks start \
  --clusterId <cluster ID> \
  --machineType psdev-worker
  --notebookId <notebook ID>
```
and saw the notebook successfully restart. Verified that `--name` was no
longer a valid CLI param for the command with
```bash
python3 -m gradient notebooks start --help
```
