### PR TITLE
fix(datasets): fix datasets files put command

### DIFF
--- a/gradient/commands/datasets.py
+++ b/gradient/commands/datasets.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     import Queue as queue
 from xml.etree import ElementTree
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urlparse
 
 import halo
 import requests

--- a/gradient/commands/datasets.py
+++ b/gradient/commands/datasets.py
@@ -560,9 +560,6 @@ class PutDatasetFilesCommand(BaseDatasetFilesCommand):
     @classmethod
     def _put(cls, path, url, content_type):
         size = os.path.getsize(path)
-        filename = os.path.basename(path)
-        o = urlparse(url)
-        url = o.geturl()
         with requests.Session() as session:
             headers = {'Content-Type': content_type}
 
@@ -635,7 +632,7 @@ class PutDatasetFilesCommand(BaseDatasetFilesCommand):
 
                         key = target_path
                         if source_path_is_file:
-                            key = source_name
+                            key += source_name
                         else:
                             if not has_trailing_slash:
                                 key += source_name + '/'

--- a/gradient/commands/datasets.py
+++ b/gradient/commands/datasets.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     import Queue as queue
 from xml.etree import ElementTree
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urljoin
 
 import halo
 import requests
@@ -560,7 +560,9 @@ class PutDatasetFilesCommand(BaseDatasetFilesCommand):
     @classmethod
     def _put(cls, path, url, content_type):
         size = os.path.getsize(path)
-
+        filename = os.path.basename(path)
+        o = urlparse(url)
+        url = o.geturl()
         with requests.Session() as session:
             headers = {'Content-Type': content_type}
 
@@ -632,7 +634,9 @@ class PutDatasetFilesCommand(BaseDatasetFilesCommand):
                         path = path.replace(os.path.sep, '/')
 
                         key = target_path
-                        if not source_path_is_file:
+                        if source_path_is_file:
+                            key = source_name
+                        else:
                             if not has_trailing_slash:
                                 key += source_name + '/'
                             key += path[len(source_path)+1:]


### PR DESCRIPTION
Overview:
The command was getting a presigned url without providing file name and would get 403'd

Test plan:
1. Create a dataset version: ```gradient datasets versions create --id <dataset id>```
2. Start various ways of putting files
```
gradient datasets files put --id <dataset ref from above> --source-path file.txt
gradient datasets files put --id <dataset ref from above> --source-path workflow.yaml --target-path helloworld/
gradient datasets files put --id <dataset ref from above> --source-path workflow.yaml --target-path helloworld/yoloswag
gradient datasets files put --id <dataset ref from above> --source-path random/test/
```
putting a file, putting a folder, putting a file in a target path
3. Commit the dataset ```python gradient datasets versions commit --id <dataset ref from above>``` 
4. Verify in CLI or UI that files are where they are expected to be