### PR TITLE
fix(workflows): make projectId required when listing workflows

### DIFF
--- a/gradient/cli/workflows.py
+++ b/gradient/cli/workflows.py
@@ -79,7 +79,7 @@ def create_workflow_run(ctx, api_key, workflow_id, cluster_id, spec_path, input_
 @click.option(
     "--projectId",
     "project_id",
-    required=False,
+    required=True,
     help="Project ID",
     cls=common.GradientOption,
 )


### PR DESCRIPTION
Results weren't returning if projectId wasn't provided. This makes the field required so there isn't confusion if not results are returned.