### PR TITLE
feat(deployments): add logs to python package

### DIFF
--- a/gradient/api_sdk/repositories/__init__.py
+++ b/gradient/api_sdk/repositories/__init__.py
@@ -41,7 +41,9 @@ from .gradient_deployments import (
     list_deployments,
     delete_deployment,
     get_deployment,
-    update_deployment
+    update_deployment,
+    get_deployment_logs,
+    yield_deployment_logs
 )
 from .experiments import (
     ListExperiments,

--- a/gradient/api_sdk/repositories/gradient_deployments.py
+++ b/gradient/api_sdk/repositories/gradient_deployments.py
@@ -1,5 +1,7 @@
 from gql import gql
 from ..graphql import graphql_client
+from .common import ListLogs
+from .. import logger as sdk_logger
 
 
 def create_deployment(name, project_id, spec, cluster_id=None, api_key=None):
@@ -215,3 +217,29 @@ def delete_deployment(id, api_key=None):
         }
     }
     return client.execute(query, variable_values=params)['deleteDeployment']
+
+
+# my disappointment is immeasurable
+# and my day is ruined
+class ListDeploymentV3Logs(ListLogs):
+    def _get_request_params(self, kwargs):
+        params = {
+            'gradientDeploymentId': kwargs['id'],
+            'line': kwargs['line'],
+            'limit': kwargs['limit']
+        }
+        return params
+
+
+def get_deployment_logs(deployment_id, line=1, limit=10000, api_key=None):
+    DeploymentLogs = ListDeploymentV3Logs(
+        api_key=api_key,
+        logger=sdk_logger.MuteLogger())
+    return DeploymentLogs.list(id=deployment_id, line=line, limit=limit)
+
+
+def yield_deployment_logs(deployment_id, line=1, limit=10000, api_key=None):
+    DeploymentLogs = ListDeploymentV3Logs(
+        api_key=api_key,
+        logger=sdk_logger.MuteLogger())
+    return DeploymentLogs.yield_logs(id=deployment_id, line=line, limit=limit)


### PR DESCRIPTION
This hijacks some old crufty log machinery to enable log streaming from
the new Deployments V3. This exposes two new methods, one generator and
one that just dumps a buttload of logs in your lap.

By way of example:
```
>>> from gradient import gradient_deployments
>>> import json
>>>
>>>
>>> logs = gradient_deployments.get_deployment_logs(
...     deployment_id='6753a6cc-393a-478d-bc29-9e8828a0aa2f',
...     limit=5,
...     api_key='<REDACTED>')
>>> print(json.dumps(logs, indent=4))
[
    [
        2,
        "",
        "2021-12-13T21:41:39.711Z"
    ],
    [
        3,
        "  Welcome to Streamlit. Check out our demo in your browser.",
        "2021-12-13T21:41:39.711Z"
    ],
    [
        4,
        "",
        "2021-12-13T21:41:39.711Z"
    ],
    [
        5,
        "  Network URL: http://10.42.40.230:8501",
        "2021-12-13T21:41:39.711Z"
    ],
    [
        6,
        "  External URL: http://172.83.13.4:8501",
        "2021-12-13T21:41:39.711Z"
    ]
]
>>>
>>> logs = gradient_deployments.yield_deployment_logs(
...     deployment_id='6753a6cc-393a-478d-bc29-9e8828a0aa2f',
...     limit=5,
...     api_key='<REDACTED>')
>>> next(logs)
LogRow(line=2, message='', timestamp='2021-12-13T21:41:39.711Z')
```
