### PR TITLE
fix(datasets): increase create version request timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ paperspace-python.zip
 bin/
 lib64
 share/
+/tmp


### PR DESCRIPTION
After some digging, it turns out that larger files were timing out due to the default timeout of 5 seconds. Since the errors are happening inside of the worker pool, they are never reported to the user.

- Increases the default timeout to 5 minutes per 15MB file
- Better use of the `requests.Session()` context so that connection pooling is used and connections to a given host are maintained between requests. This should yield slightly better performance for parallel uploads.
- Report progress to the user more often (every chunk). There is still much room for improvement here :)
 
### Screenshots

<img width="384" alt="Screen Shot 2022-06-21 at 8 28 52 PM" src="https://user-images.githubusercontent.com/98760247/174931049-dead3fcf-fca5-4e2f-b8ed-209053acc65d.png">

https://user-images.githubusercontent.com/98760247/174931085-fe9ccc77-c43d-4024-a26f-6bd8ffbaa195.mov

