### PR TITLE
update PyYAML version to 5.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         'halo',
         'marshmallow<3.0',
         'attrs<=19',
-        'PyYAML==5.*',
+        'PyYAML==5.3.1',
         'python-dateutil==2.*',
         'websocket-client==0.57.*',
         'gradient-utils>=0.1.2',


### PR DESCRIPTION
Update PyYAML version to 5.3.1 to avoid running into the following error when installing with python > 3.11.

There is a PyYAML bug in 5.4 versions which caused the issue. See https://github.com/yaml/pyyaml/issues/724 for details.

```
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [54 lines of output]
      running egg_info
      writing lib3/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib3/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 351, in <module>
          main()
        File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 333, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 327, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 297, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 271, in <module>
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/__init__.py", line 108, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 184, in setup
          return run_commands(dist)
                 ^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 200, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 970, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/dist.py", line 956, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 989, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 310, in run
          self.find_sources()
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 318, in find_sources
          mm.run()
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 539, in run
          self.add_defaults()
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 577, in add_defaults
          sdist.add_defaults(self)
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/command/sdist.py", line 102, in add_defaults
          super().add_defaults()
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 250, in add_defaults
          self._add_defaults_ext()
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 335, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "<string>", line 201, in get_source_files
        File "/tmp/pip-build-env-ca0l7y2z/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```